### PR TITLE
Handle missing values in create/replace datasets

### DIFF
--- a/src/schema.jl
+++ b/src/schema.jl
@@ -1,15 +1,15 @@
 # function to match Julia's types to Domo's
 #  according to Docs, accepted values are STRING, DECIMAL, LONG, DOUBLE, DATE, and DATETIME.
 function match_domo_types(type)
-    if type == String | type == Union{String, Missing}
+    if type == String || type == Union{String, Missing}
         "STRING"
-    elseif type in [Int64, Int32] | type in [Union{Int64, Missing}, Union{Int32, Missing}]
+    elseif type in [Int64, Int32] || type in [Union{Int64, Missing}, Union{Int32, Missing}]
         "LONG"
-    elseif type in [Float64, Float32] | type in [Union{Float64, Missing}, Union{Float32, Missing}]
+    elseif type in [Float64, Float32] || type in [Union{Float64, Missing}, Union{Float32, Missing}]
         "DOUBLE"
-    elseif type == Dates.Date | type == Union{Dates.Date, Missing}
+    elseif type == Dates.Date || type == Union{Dates.Date, Missing}
         "DATE"
-    elseif type == Dates.DateTime | type == Union{Dates.Date, Missing}
+    elseif type == Dates.DateTime || type == Union{Dates.Date, Missing}
         "DATETIME"
     end
 end

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -1,15 +1,15 @@
 # function to match Julia's types to Domo's
 #  according to Docs, accepted values are STRING, DECIMAL, LONG, DOUBLE, DATE, and DATETIME.
-function match_domo_types(type::DataType)
-    if type == String # yes, I will expand this eventually...;)
+function match_domo_types(type)
+    if type == String | type == Union{String, Missing}
         "STRING"
-    elseif type in [Int64, Int32]
+    elseif type in [Int64, Int32] | type in [Union{Int64, Missing}, Union{Int32, Missing}]
         "LONG"
-    elseif type in [Float64, Float32]
+    elseif type in [Float64, Float32] | type in [Union{Float64, Missing}, Union{Float32, Missing}]
         "DOUBLE"
-    elseif type == Dates.Date
+    elseif type == Dates.Date | type == Union{Dates.Date, Missing}
         "DATE"
-    elseif type == Dates.DateTime
+    elseif type == Dates.DateTime | type == Union{Dates.Date, Missing}
         "DATETIME"
     end
 end

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -9,7 +9,7 @@ function match_domo_types(type)
         "DOUBLE"
     elseif type == Dates.Date || type == Union{Dates.Date, Missing}
         "DATE"
-    elseif type == Dates.DateTime || type == Union{Dates.Date, Missing}
+    elseif type == Dates.DateTime || type == Union{Dates.DateTime, Missing}
         "DATETIME"
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using JuDOMO
 using Test
 include("test-sets/schema-tests.jl")
 
-@testset "JuDOMO.jl" begin
+@testset "Schemas" begin
     # test whether create_dataset_schema() creates the correct structure on a simple dataset
     @test create_dataset_schema(
         schema_test_mathematicians_dataset,
@@ -20,4 +20,4 @@ include("test-sets/schema-tests.jl")
     map(1:length(types)) do type
         @test match_domo_types(types[type]) == expected_types[type]
     end
-end
+end;

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,12 @@ include("test-sets/schema-tests.jl")
         "Leonhard Euler Party",
         "Mathematician guest list."
     ) == schema_test_mathematicians
+    # test whether schema accounts for nulls
+    @test create_dataset_schema(
+        null_schema_test_df,
+        "The Crows Outside My Apartment",
+        "A partial list of friends."
+    ) == schema_test_nulls
     # test whether types match
     #  (note that mapping here runs multiple tests)
     map(1:length(types)) do type

--- a/test/test-sets/schema-tests.jl
+++ b/test/test-sets/schema-tests.jl
@@ -13,13 +13,13 @@ schema_test_mathematicians = Dict(
     "description" => "Mathematician guest list.",
     "rows" => 3,
     "schema" => Dict(
-        "columns" => [ Dict(
+        "columns" => [Dict(
             "type" => "STRING",
             "name" => "Friend"
         ), Dict(
             "type" => "STRING",
             "name" => "Attending"
-        ) ]
+        )]
     )
 ) |> json
 
@@ -27,3 +27,34 @@ schema_test_mathematicians_dataset = DataFrame(
     "Friend" => ["Pythagoras", "Alan Turing", "George Boole"],
     "Attending" => ["TRUE", "TRUE", "FALSE"]
 )
+
+## test whether columns that contain null values are properly schema-d.
+schema_test_nulls = Dict(
+    "name" => "The Crows Outside My Apartment",
+    "description" => "A partial list of friends.",
+    "rows" => 5,
+    "schema" => Dict(
+        "columns" => [Dict(
+            "type" => "STRING",
+            "name" => "Friend"
+        ), Dict(
+            "type" => "STRING",
+            "name" => "Visited"
+        ), Dict(
+            "type" => "LONG",
+            "name" => "Approximate Peanuts Eaten"
+        )]
+    )
+) |> json
+
+null_schema_test_df = DataFrame(
+    "Friend" => ["Peanut", "Cindy", missing, "Gumbo", "Flynn"],
+    "Visited" => ["TRUE", missing, "FALSE", "TRUE", "FALSE"],
+    "Approximate Peanuts Eaten" => [1, missing, missing, 3, 5]
+)
+
+create_dataset_schema(
+        null_schema_test_df,
+        "The Crows Outside My Apartment",
+        "A partial list of friends."
+    )

--- a/test/test-sets/schema-tests.jl
+++ b/test/test-sets/schema-tests.jl
@@ -16,7 +16,9 @@ types = [
     Union{Int32, Missing},
     Union{Float64, Missing},
     Union{Float32, Missing},
-    Union{String, Missing}
+    Union{String, Missing},
+    Union{Dates.Date, Missing},
+    Union{Dates.DateTime, Missing}
 ]
 
 expected_types = [
@@ -31,7 +33,9 @@ expected_types = [
     "LONG",
     "DOUBLE",
     "DOUBLE",
-    "STRING"
+    "STRING",
+    "DATE",
+    "DATETIME"
 ]
 
 ## test sets for schema creation

--- a/test/test-sets/schema-tests.jl
+++ b/test/test-sets/schema-tests.jl
@@ -4,8 +4,35 @@ import DataFrames: DataFrame
 using Dates
 
 ## test sets for matching Julia's types to Domo's
-types = [Int32, Int64, Float32, Float64, String, Dates.Date, Dates.DateTime]
-expected_types = ["LONG", "LONG", "DOUBLE", "DOUBLE", "STRING", "DATE", "DATETIME"]
+types = [
+    Int32,
+    Int64,
+    Float32,
+    Float64,
+    String,
+    Dates.Date,
+    Dates.DateTime,
+    Union{Int64, Missing},
+    Union{Int32, Missing},
+    Union{Float64, Missing},
+    Union{Float32, Missing},
+    Union{String, Missing}
+]
+
+expected_types = [
+    "LONG",
+    "LONG",
+    "DOUBLE",
+    "DOUBLE",
+    "STRING",
+    "DATE",
+    "DATETIME",
+    "LONG",
+    "LONG",
+    "DOUBLE",
+    "DOUBLE",
+    "STRING"
+]
 
 ## test sets for schema creation
 schema_test_mathematicians = Dict(


### PR DESCRIPTION
This PR adds in functionality to handle missing values in API calls. 

In Julia, missing values are represented as a `Union` of a column's type and the `Missing` data type. I added some logic to the `match_domo_types` function to handle this. I also added some tests to verify this works as intended.