### PR TITLE
Eliminate CSV.jl dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,15 +5,14 @@ version = "0.1.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
-CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 
 [compat]
-JSON = "0.21"
 DataFrames = "1"
+JSON = "0.21"
 julia = "1"
 
 [extras]

--- a/src/DOMO.jl
+++ b/src/DOMO.jl
@@ -6,7 +6,7 @@ include("utils.jl")
 import HTTP: request, iserror
 import JSON: parse, json
 import Base64: base64encode
-import DataFrames: nrow, ncol
+import DataFrames: nrow, ncol, rownumber, eachrow
 import CSV: write
 using Dates
 

--- a/src/DOMO.jl
+++ b/src/DOMO.jl
@@ -6,8 +6,7 @@ include("utils.jl")
 import HTTP: request, iserror
 import JSON: parse, json
 import Base64: base64encode
-import DataFrames: nrow, ncol, rownumber, eachrow
-import CSV: write
+import DataFrames: nrow, ncol, rownumber, eachrow, eachcol
 using Dates
 
 export DOMO_auth

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -32,12 +32,7 @@ function replace_dataset(dataset_id::String, df)
 
     access_token = domo["access_token"]
 
-    io = IOBuffer()
-    write(io, df; newline = "\n", writeheader = false, append = false)
-    data = replace(
-        String(io.data),
-        "\n\0\0\0\0\0\0" => ""
-    )
+    data = create_csv_structure(df)
 
     response = PUT_data(data, dataset_id, access_token)
 

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -18,12 +18,7 @@ function create_dataset(df; name::String = "", description::String = "")
     schema = create_dataset_schema(df, name, description)
     pushed_schema = push_schema_to_domo(schema) |> parse_HTTP_response
 
-    io = IOBuffer()
-    write(io, df; newline = "\n", writeheader = false)
-    data = replace(
-        String(io.data),
-        "\n\0\0\0\0\0\0" => ""
-    )
+    data = create_csv_structure(df)
 
     response = PUT_data(data, pushed_schema["id"], access_token)
 

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -41,13 +41,25 @@ function create_csv_structure(df)
     csv_data = ""
     for row in eachrow(df), col_num in 1:ncol(df)
         if col_num < ncol(df) && rownumber(row) < nrow(df)
-            csv_data = csv_data * string(row[col_num]) * ","
+            csv_data = csv_data * string(
+                if ismissing(row[col_num]) "" else row[col_num] end
+            ) * ","
         elseif col_num == ncol(df) && rownumber(row) < nrow(df)
-            csv_data = csv_data * (string(row[col_num]) * "\\n")
+            csv_data = csv_data * (
+                string(
+                    if ismissing(row[col_num]) "" else row[col_num] end
+                ) * "\\n"
+            )
         elseif col_num < ncol(df) && rownumber(row) == nrow(df)
-            csv_data = csv_data * (string(row[col_num]) * ",")
+            csv_data = csv_data * (
+                string(
+                    if ismissing(row[col_num]) "" else row[col_num] end
+                ) * ","
+            )
         elseif col_num == ncol(df) && rownumber(row) == nrow(df)
-            csv_data = csv_data * string(row[col_num])
+            csv_data = csv_data * string(
+                if ismissing(row[col_num]) "" else row[col_num] end
+            )
         end
     end
 

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -36,6 +36,24 @@ function create_dataset_schema(df, name, description)
     json(schema)
 end
 
+## create csv structure for dataset to be sent to Domo.
+function create_csv_structure(df)
+    csv_data = ""
+    for row in eachrow(df), col_num in 1:ncol(df)
+        if col_num < ncol(df) && rownumber(row) < nrow(df)
+            csv_data = csv_data * string(row[col_num]) * ","
+        elseif col_num == ncol(df) && rownumber(row) < nrow(df)
+            csv_data = csv_data * (string(row[col_num]) * "\\n")
+        elseif col_num < ncol(df) && rownumber(row) == nrow(df)
+            csv_data = csv_data * (string(row[col_num]) * ",")
+        elseif col_num == ncol(df) && rownumber(row) == nrow(df)
+            csv_data = csv_data * string(row[col_num])
+        end
+    end
+
+    return csv_data
+end
+
 ## send the schema to Domo.
 function push_schema_to_domo(dataset_schema)
     request(

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -39,6 +39,7 @@ end
 ## create csv structure for dataset to be sent to Domo.
 function create_csv_structure(df)
     csv_data = ""
+
     for row in eachrow(df), col_num in 1:ncol(df)
         if col_num < ncol(df) && rownumber(row) < nrow(df)
             csv_data = csv_data * string(

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -1,7 +1,7 @@
 # function to match Julia's types to Domo's
 #  according to Docs, accepted values are STRING, DECIMAL, LONG, DOUBLE, DATE, and DATETIME.
 function match_domo_types(type)
-    if type == String || type == Union{String, Missing}
+    if type == String || type == Union{String, Missing} || type == Bool || type == Union{Bool, Missing}
         "STRING"
     elseif type in [Int64, Int32] || type in [Union{Int64, Missing}, Union{Int32, Missing}]
         "LONG"
@@ -33,7 +33,7 @@ function create_dataset_schema(df, name, description)
         "schema" => column_schema
     )
 
-    json(schema)
+    return json(schema)
 end
 
 ## create csv structure for dataset to be sent to Domo.

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -43,23 +43,23 @@ function create_csv_structure(df)
     for row in eachrow(df), col_num in 1:ncol(df)
         if col_num < ncol(df) && rownumber(row) < nrow(df)
             csv_data = csv_data * string(
-                if ismissing(row[col_num]) "" else row[col_num] end
+                ifelse(ismissing(row[col_num]), "", row[col_num])
             ) * ","
         elseif col_num == ncol(df) && rownumber(row) < nrow(df)
             csv_data = csv_data * (
                 string(
-                    if ismissing(row[col_num]) "" else row[col_num] end
+                    ifelse(ismissing(row[col_num]), "", row[col_num])
                 ) * "\n"
             )
         elseif col_num < ncol(df) && rownumber(row) == nrow(df)
             csv_data = csv_data * (
                 string(
-                    if ismissing(row[col_num]) "" else row[col_num] end
+                    ifelse(ismissing(row[col_num]), "", row[col_num])
                 ) * ","
             )
         elseif col_num == ncol(df) && rownumber(row) == nrow(df)
             csv_data = csv_data * string(
-                if ismissing(row[col_num]) "" else row[col_num] end
+                ifelse(ismissing(row[col_num]), "", row[col_num])
             ) * "\n"
         end
     end

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -69,7 +69,7 @@ end
 
 ## send the schema to Domo.
 function push_schema_to_domo(dataset_schema)
-    request(
+    response = request(
         "POST",
         "https://api.domo.com/v1/datasets",
         [

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -48,7 +48,7 @@ function create_csv_structure(df)
             csv_data = csv_data * (
                 string(
                     if ismissing(row[col_num]) "" else row[col_num] end
-                ) * "\\n"
+                ) * "\n"
             )
         elseif col_num < ncol(df) && rownumber(row) == nrow(df)
             csv_data = csv_data * (
@@ -59,7 +59,7 @@ function create_csv_structure(df)
         elseif col_num == ncol(df) && rownumber(row) == nrow(df)
             csv_data = csv_data * string(
                 if ismissing(row[col_num]) "" else row[col_num] end
-            )
+            ) * "\n"
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,5 +21,6 @@ include("test-sets/schema-tests.jl")
         @test match_domo_types(types[type]) == expected_types[type]
     end
     # test whether behavior of csv creator is valid
-    @test create_csv_structure(schema_test_mathematicians_dataset) == test_csv_string
+    @test create_csv_structure(schema_test_mathematicians_dataset) == test_csv_string_math
+    @test create_csv_structure(null_schema_test_df) == test_csv_string_crows
 end;

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,4 +20,6 @@ include("test-sets/schema-tests.jl")
     map(1:length(types)) do type
         @test match_domo_types(types[type]) == expected_types[type]
     end
+    # test whether behavior of csv creator is valid
+    @test create_csv_structure(schema_test_mathematicians_dataset) == test_csv_string
 end;

--- a/test/test-sets/schema-tests.jl
+++ b/test/test-sets/schema-tests.jl
@@ -85,4 +85,6 @@ null_schema_test_df = DataFrame(
 )
 
 # test string for math friends
-test_csv_string = "Pythagoras,TRUE\\nAlan Turing,TRUE\\nGeorge Boole,FALSE"
+test_csv_string_math = "Pythagoras,TRUE\\nAlan Turing,TRUE\\nGeorge Boole,FALSE"
+# test string for crow friends
+test_csv_string_crows = "Peanut,TRUE,1\\nCindy,,\\n,FALSE,\\nGumbo,TRUE,3\\nFlynn,FALSE,5"

--- a/test/test-sets/schema-tests.jl
+++ b/test/test-sets/schema-tests.jl
@@ -1,4 +1,4 @@
-import DOMO: match_domo_types, create_dataset_schema
+import DOMO: match_domo_types, create_dataset_schema, create_csv_structure
 import JSON: json
 import DataFrames: DataFrame
 using Dates
@@ -84,8 +84,5 @@ null_schema_test_df = DataFrame(
     "Approximate Peanuts Eaten" => [1, missing, missing, 3, 5]
 )
 
-create_dataset_schema(
-        null_schema_test_df,
-        "The Crows Outside My Apartment",
-        "A partial list of friends."
-    )
+# test string for math friends
+test_csv_string = "Pythagoras,TRUE\\nAlan Turing,TRUE\\nGeorge Boole,FALSE"

--- a/test/test-sets/schema-tests.jl
+++ b/test/test-sets/schema-tests.jl
@@ -85,6 +85,6 @@ null_schema_test_df = DataFrame(
 )
 
 # test string for math friends
-test_csv_string_math = "Pythagoras,TRUE\\nAlan Turing,TRUE\\nGeorge Boole,FALSE\n"
+test_csv_string_math = "Pythagoras,TRUE\nAlan Turing,TRUE\nGeorge Boole,FALSE\n"
 # test string for crow friends
 test_csv_string_crows = "Peanut,TRUE,1\nCindy,,\n,FALSE,\nGumbo,TRUE,3\nFlynn,FALSE,5\n"

--- a/test/test-sets/schema-tests.jl
+++ b/test/test-sets/schema-tests.jl
@@ -85,6 +85,6 @@ null_schema_test_df = DataFrame(
 )
 
 # test string for math friends
-test_csv_string_math = "Pythagoras,TRUE\\nAlan Turing,TRUE\\nGeorge Boole,FALSE"
+test_csv_string_math = "Pythagoras,TRUE\\nAlan Turing,TRUE\\nGeorge Boole,FALSE\n"
 # test string for crow friends
-test_csv_string_crows = "Peanut,TRUE,1\\nCindy,,\\n,FALSE,\\nGumbo,TRUE,3\\nFlynn,FALSE,5"
+test_csv_string_crows = "Peanut,TRUE,1\nCindy,,\n,FALSE,\nGumbo,TRUE,3\nFlynn,FALSE,5\n"


### PR DESCRIPTION
This PR eliminates the dependency on `CSV.jl` by parsing Julia DataFrames directly to their CSV equivalent with code. Some benefits to this approach:
1) eliminates a dependency.
2) is a bit faster as it eliminates an IO step.
3) it's more stable, as I found the previous CSV/IO approach resulted in some unexpected behavior like trailing nulls.
4) I think it's a bit more testable :) 