### PR TITLE
Update to use JSON3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DOMO"
 uuid = "72b704fe-efc7-41fd-b723-a3ca9fa252d1"
 authors = ["Michael Johnson"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/Project.toml
+++ b/Project.toml
@@ -8,11 +8,10 @@ Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 
 [compat]
 DataFrames = "1"
-JSON = "0.21"
 julia = "1"
 
 [extras]

--- a/src/DOMO.jl
+++ b/src/DOMO.jl
@@ -4,7 +4,7 @@ include("datasets.jl")
 include("utils.jl")
 
 import HTTP: request, iserror
-import JSON: parse, json
+using JSON3
 import Base64: base64encode
 import DataFrames: DataFrame, nrow, ncol, rownumber, eachrow, eachcol
 using Dates

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -41,7 +41,7 @@ function create_dataset_schema(df, name, description)
         "schema" => column_schema
     )
 
-    return json(schema)
+    return JSON3.write(schema)
 end
 
 function create_csv_string(row, col_num)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,6 @@
 # function which parses the body of an HTTP response into a dictionary object.
 function parse_HTTP_response(http_response)
-    parse(
+    JSON3.read(
         String(http_response.body)
     )
 end

--- a/test/test-sets/schema-tests.jl
+++ b/test/test-sets/schema-tests.jl
@@ -1,5 +1,5 @@
 import DOMO: match_domo_types, create_dataset_schema, create_csv_structure
-import JSON: json
+using JSON3
 import DataFrames: DataFrame
 using Dates
 
@@ -76,7 +76,7 @@ schema_test_nulls = Dict(
             "name" => "Approximate Peanuts Eaten"
         )]
     )
-) |> json
+) |> JSON3.write
 
 null_schema_test_df = DataFrame(
     "Friend" => ["Peanut", "Cindy", missing, "Gumbo", "Flynn"],

--- a/test/test-sets/schema-tests.jl
+++ b/test/test-sets/schema-tests.jl
@@ -52,7 +52,7 @@ schema_test_mathematicians = Dict(
             "name" => "Attending"
         )]
     )
-) |> json
+) |> JSON3.write
 
 schema_test_mathematicians_dataset = DataFrame(
     "Friend" => ["Pythagoras", "Alan Turing", "George Boole"],


### PR DESCRIPTION
It seems that the preferred/widely used JSON package for Julia is [JSON3](https://quinnj.github.io/JSON3.jl/stable/). This is a quick update which:

1) bumps the package version
2) updates the `Project.toml` and manifest to use JSON3 
3) source code now uses JSON3

The functions work similarly to the old ones, so nothing huge happening.