### PR TITLE
More robust type detection

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DOMO"
 uuid = "72b704fe-efc7-41fd-b723-a3ca9fa252d1"
 authors = ["Michael Johnson"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ url = "https://gist.githubusercontent.com/seankross/a412dfbd88b3db70b74b/raw/5f2
 
 mtcars = CSV.read(
     download(url), 
-    DataFrame, 
-    types = Dict(1 => String) # note the specified type here for column 1.
+    DataFrame # note the specified type here for column 1.
 ) 
 
 DOMO_auth(client_id, client_secret)

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ url = "https://gist.githubusercontent.com/seankross/a412dfbd88b3db70b74b/raw/5f2
 
 mtcars = CSV.read(
     download(url), 
-    DataFrame # note the specified type here for column 1.
-) 
+    DataFrame
+)
 
 DOMO_auth(client_id, client_secret)
 #> Authentication complete.

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -58,7 +58,7 @@ end
 
 Returns a list of all datasets in the Domo instance as a DataFrame.
 """
-function list_datasets(;limit = 50, name = "", offset = 0, owner_id = "", order_by = "")
+function list_datasets(;limit = 50, name = "", offset = 0, order_by = "")
     if !(@isdefined domo)
         error("Please run the DOMO_auth() function to generate an access token.")
     end

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -6,7 +6,7 @@ This function helps match types in Julia to those accepted by the Domo API.
 This is an internal function used by the package, it may come in handy if you're trying to extend the API.
 """
 function match_domo_types(type)
-    if type <: AbstractString || type == Union{AbstractString, Missing} || type <: Bool || type == Union{Bool, Missing}
+    if type <: AbstractString || type <: Union{AbstractString, Missing} || type <: Bool || type == Union{Bool, Missing}
         "STRING"
     elseif type <: Integer || type <: Union{Integer, Missing}
         "LONG"

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -6,15 +6,15 @@ This function helps match types in Julia to those accepted by the Domo API.
 This is an internal function used by the package, it may come in handy if you're trying to extend the API.
 """
 function match_domo_types(type)
-    if type <: AbstractString || type == Union{String, Missing} || type <: Bool || type == Union{Bool, Missing}
+    if type <: AbstractString || type == Union{AbstractString, Missing} || type <: Bool || type == Union{Bool, Missing}
         "STRING"
-    elseif type <: Integer || type in [Union{Int64, Missing}, Union{Int32, Missing}]
+    elseif type <: Integer || type <: Union{Integer, Missing}
         "LONG"
-    elseif type <: AbstractFloat || type in [Union{Float64, Missing}, Union{Float32, Missing}]
+    elseif type <: AbstractFloat || type <: Union{AbstractFloat, Missing}
         "DOUBLE"
-    elseif type <: Dates.Date || type == Union{Dates.Date, Missing}
+    elseif type <: Dates.Date || type <: Union{Dates.Date, Missing}
         "DATE"
-    elseif type <: Dates.DateTime || type == Union{Dates.DateTime, Missing}
+    elseif type <: Dates.DateTime || type <: Union{Dates.DateTime, Missing}
         "DATETIME"
     end
 end

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -6,15 +6,15 @@ This function helps match types in Julia to those accepted by the Domo API.
 This is an internal function used by the package, it may come in handy if you're trying to extend the API.
 """
 function match_domo_types(type)
-    if type == String || type == Union{String, Missing} || type == Bool || type == Union{Bool, Missing}
+    if type <: AbstractString || type == Union{String, Missing} || type <: Bool || type == Union{Bool, Missing}
         "STRING"
-    elseif type in [Int64, Int32] || type in [Union{Int64, Missing}, Union{Int32, Missing}]
+    elseif type <: Integer || type in [Union{Int64, Missing}, Union{Int32, Missing}]
         "LONG"
-    elseif type in [Float64, Float32] || type in [Union{Float64, Missing}, Union{Float32, Missing}]
+    elseif type <: AbstractFloat || type in [Union{Float64, Missing}, Union{Float32, Missing}]
         "DOUBLE"
-    elseif type == Dates.Date || type == Union{Dates.Date, Missing}
+    elseif type <: Dates.Date || type == Union{Dates.Date, Missing}
         "DATE"
-    elseif type == Dates.DateTime || type == Union{Dates.DateTime, Missing}
+    elseif type <: Dates.DateTime || type == Union{Dates.DateTime, Missing}
         "DATETIME"
     end
 end

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -6,7 +6,7 @@ This function helps match types in Julia to those accepted by the Domo API.
 This is an internal function used by the package, it may come in handy if you're trying to extend the API.
 """
 function match_domo_types(type)
-    if type <: AbstractString || type <: Union{AbstractString, Missing} || type <: Bool || type == Union{Bool, Missing}
+    if type <: AbstractString || type <: Union{AbstractString, Missing} || type <: Bool || type <: Union{Bool, Missing}
         "STRING"
     elseif type <: Integer || type <: Union{Integer, Missing}
         "LONG"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,8 +1,6 @@
 # function which parses the body of an HTTP response into a dictionary object.
 function parse_HTTP_response(http_response)
-    JSON3.read(
-        String(http_response.body)
-    )
+    JSON3.read(String(http_response.body))
 end
 
 function PUT_data(data::String, dataset_id::String, access_token::String)


### PR DESCRIPTION
Another quick update which improves type detection in the `match_domo_types()` function.

Instead of checking equality individually, this takes advantage of Julia's type hierarchy to test whether the type of a DataFrame's column is a subtype of some other Abstract Type. 

For example, in the mtcars dataset used in the `readme.md` example, we previously had to specify the column type as a `String` for column 1 because it was read into Julia as `String31`. 

However, we can verify that this `String31` type is actually a subtype of an `AbstractString`:

```julia
String31 <: AbstractString
#> true
```

Thus, we can check the other types as well such as `Int32`, `Int64`, and so on with the `<:` operator instead of checking for equality. My hope is that this makes the conversion to Domo's types a bit more robust and less brittle.