### PR TITLE
Replace CSV structure functions with a simpler method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DOMO"
 uuid = "72b704fe-efc7-41fd-b723-a3ca9fa252d1"
 authors = ["Michael Johnson"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.3"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,6 @@ include("test-sets/schema-tests.jl")
         @test match_domo_types(types[type]) == expected_types[type]
     end
     # test whether behavior of csv creator is valid
-    @test create_csv_structure(schema_test_mathematicians_dataset) == test_csv_string_math
-    @test create_csv_structure(null_schema_test_df) == test_csv_string_crows
+    @test dataframe_to_csv(schema_test_mathematicians_dataset) == test_csv_string_math
+    @test dataframe_to_csv(null_schema_test_df) == test_csv_string_crows
 end;

--- a/test/test-sets/schema-tests.jl
+++ b/test/test-sets/schema-tests.jl
@@ -1,4 +1,4 @@
-import DOMO: match_domo_types, create_dataset_schema, create_csv_structure
+import DOMO: match_domo_types, create_dataset_schema, dataframe_to_csv
 using JSON3
 import DataFrames: DataFrame
 using Dates


### PR DESCRIPTION
This PR strips out some convoluted functions I wrote and replaces them with a simpler one. 

The function uses `CSV.jl` and an IO buffer to accomplish the same thing more concisely. My reasoning here is that I trust `CSV` to generate the correct structure far more than I trust my functions to do the same thing. It's also much more concise code-wise.

